### PR TITLE
migrate to qt5

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ The main purpose of this application is to provide GUI functionality to shell sc
 This is a Qt application and it introduces all the power of Qt to shell scripts from command buttons through stylesheets and animations.
 
 #### Software Requirements
-This application was designed for Qt 4.8, but the new versions will be using the Qt 5 library. It must be portable across systems supported by the Qt libraries, but the author tested it in GNU/Linux environment only.
+This application is designed using Qt libraries, and you can select if to compile using the QT 4.8 or Qt 5 library. It must be portable across systems supported by the Qt libraries, but the author tested it in GNU/Linux environment only.
 
 To compile the application from the source code the following packages must also be installed on a GNU/Linux system - build-time dependencies:
 - g++
 - make
-- qtbase5-dev
+- libqt4-dev (only if compiling for QT 4.8 library)
+- qtbase5-dev (only if compiling for QT 5 library)
 
 #### Downloading
 The latest released version of the `dialogbox` application can be checked by the link below:
@@ -54,18 +55,21 @@ The `dialogbox` project is also available via Git access from the GitHub server:
 https://github.com/martynets/dialogbox.git
 
 #### Installation
-To compile and install the application issue the following commands from the source directory:
+First, before compiling, create the makefile with qmake. For QT 4, run from the source directory:
+```
+qmake -qt=qt4 -makefile
+```
+For QT5, you need to run instead:
+```
+qmake -qt=qt5 -makefile
+```
+To compile and install the application, issue the following commands from the source directory:
 ```
 qmake
 make
 make install
 ```
 > Note: the application is installed in `/usr/bin` directory and thus the last one command requires root privileges
-
-If you want to make sure that it compiles using Qt5 libraries, select it as the default.
-```
-export QT_SELECT=qt5
-```
 
 To uninstall the application issue the following command from the same directory (the same note is applicable here):
 ```

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ The main purpose of this application is to provide GUI functionality to shell sc
 This is a Qt application and it introduces all the power of Qt to shell scripts from command buttons through stylesheets and animations.
 
 #### Software Requirements
-This application is designed using the Qt 4.8 library and this is the only run-time dependency. It must be portable across systems supported by the Qt but the author tested it in GNU/Linux environment only.
+This application was designed for Qt 4.8, but the new versions will be using the Qt 5 library. It must be portable across systems supported by the Qt libraries, but the author tested it in GNU/Linux environment only.
 
 To compile the application from the source code the following packages must also be installed on a GNU/Linux system - build-time dependencies:
 - g++
 - make
-- libqt4-dev
+- qtbase5-dev
 
 #### Downloading
 The latest released version of the `dialogbox` application can be checked by the link below:
@@ -61,6 +61,11 @@ make
 make install
 ```
 > Note: the application is installed in `/usr/bin` directory and thus the last one command requires root privileges
+
+If you want to make sure that it compiles using Qt5 libraries, select it as the default.
+```
+export QT_SELECT=qt5
+```
 
 To uninstall the application issue the following command from the same directory (the same note is applicable here):
 ```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ qmake -qt=qt5 -makefile
 ```
 To compile and install the application, issue the following commands from the source directory:
 ```
-qmake
 make
 make install
 ```

--- a/dialogbox.pro
+++ b/dialogbox.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 CONFIG += qt thread release
-QT +=
+QT += widgets
 
 TARGET = dialogbox
 VPATH = src

--- a/dialogbox.pro
+++ b/dialogbox.pro
@@ -1,6 +1,8 @@
 TEMPLATE = app
 CONFIG += qt thread release
-QT += widgets
+greaterThan(QT_MAJOR_VERSION, 4) {
+    QT += widgets
+}
 
 TARGET = dialogbox
 VPATH = src

--- a/src/dialogbox.h
+++ b/src/dialogbox.h
@@ -23,7 +23,7 @@
 #ifndef DIALOGBOX_H_
 #define DIALOGBOX_H_
 
-#include <QtGui>
+#include <QtWidgets>
 
 #define DEFAULT_ALIGNMENT Qt::Alignment(0)
 #define GRAPHICS_ALIGNMENT Qt::AlignCenter

--- a/src/dialogbox.h
+++ b/src/dialogbox.h
@@ -23,7 +23,12 @@
 #ifndef DIALOGBOX_H_
 #define DIALOGBOX_H_
 
-#include <QtWidgets>
+#include <QtGlobal>
+#if QT_VERSION >= 0x050000
+    #include <QtWidgets>
+#else
+    #include <QtGui>
+#endif
 
 #define DEFAULT_ALIGNMENT Qt::Alignment(0)
 #define GRAPHICS_ALIGNMENT Qt::AlignCenter


### PR DESCRIPTION
Hi.
First, thank you very much for creating dialogbox.
As Debian is removing all gtk2 libraries, I have been searching for a replacement for gtkdialog. I found your project and I am learning how to create dialogs with your project dialogbox. I realized that qt 4.8 libraries are also being removed from Debian, so I tried and think I have succeeded porting your project to qt5. It was extremely easy as you have organized it very well. I only needed to edit 2 lines and now it compiles using qt5 libraries.

There is still a lot I need to learn and test, but I think these changes should also work for you. If you are interested in migrating to qt5 and testing the project with these libraries, please see if it works for you before accepting this merge request.

I hope I can trouble you in the future if I encounter things I don't understand and need a bit of your support.

Regards.